### PR TITLE
jobs: update tasks to use aarch64 images

### DIFF
--- a/jobs/pytechco-employee.nomad.hcl
+++ b/jobs/pytechco-employee.nomad.hcl
@@ -32,7 +32,7 @@ EOH
       driver = "docker"
 
       config {
-        image = "ghcr.io/hashicorp-education/learn-nomad-getting-started/ptc-employee:1.0"
+        image = "ghcr.io/raphlopez/learn-nomad-getting-started/ptc-employee:1.0"
         // args = [
         //     "--employee-type", "sales_engineer"
         // ]

--- a/jobs/pytechco-setup.nomad.hcl
+++ b/jobs/pytechco-setup.nomad.hcl
@@ -24,7 +24,7 @@ EOH
       driver = "docker"
 
       config {
-        image = "ghcr.io/hashicorp-education/learn-nomad-getting-started/ptc-setup:1.0"
+        image = "ghcr.io/raphlopez/learn-nomad-getting-started/ptc-setup:1.0"
       }
     }
   }

--- a/jobs/pytechco-web.nomad.hcl
+++ b/jobs/pytechco-web.nomad.hcl
@@ -32,7 +32,7 @@ EOH
       driver = "docker"
 
       config {
-        image = "ghcr.io/hashicorp-education/learn-nomad-getting-started/ptc-web:1.0"
+        image = "ghcr.io/raphlopez/learn-nomad-getting-started/ptc-web:1.0"
         ports = ["web"]
       }
     }


### PR DESCRIPTION
The images in the source repo are built for x86_64. Update the tasks to point to images that have been rebuilt for aarch64 platforms